### PR TITLE
chore: Chrome Extension 1.3.2 release

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -2,7 +2,7 @@
   "name": "__MSG_app_name__",
   "description": "__MSG_app_description__",
   "default_locale": "en",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "manifest_version": 3,
   "permissions": ["activeTab", "scripting", "storage"],
   "host_permissions": ["<all_urls>"],

--- a/chrome-extension/package-lock.json
+++ b/chrome-extension/package-lock.json
@@ -6,16 +6,16 @@
     "": {
       "license": "MIT",
       "dependencies": {
-        "@simplepdf/web-embed-pdf": "^1.8.1"
+        "@simplepdf/web-embed-pdf": "^1.8.2"
       },
       "devDependencies": {
         "prettier": "^3.3.3"
       }
     },
     "node_modules/@simplepdf/web-embed-pdf": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@simplepdf/web-embed-pdf/-/web-embed-pdf-1.8.1.tgz",
-      "integrity": "sha512-dI4NqbwVUga6jSiNDiPiw5mAe+Su5bGo7pjmpN70oc+h+c0P2wzK018DQ7WtRDoMNvFGmflJ9HX9eW/kZzebXg=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@simplepdf/web-embed-pdf/-/web-embed-pdf-1.8.2.tgz",
+      "integrity": "sha512-7Dje+sR9u5egC7sWMuDsvWFzRfvwHEUO/2R/vxm2tRkTLrFU4aFHT3sy3Bis99xMzSxujYF8t0pzKVvXmVzBcQ=="
     },
     "node_modules/prettier": {
       "version": "3.3.3",
@@ -35,9 +35,9 @@
   },
   "dependencies": {
     "@simplepdf/web-embed-pdf": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@simplepdf/web-embed-pdf/-/web-embed-pdf-1.8.1.tgz",
-      "integrity": "sha512-dI4NqbwVUga6jSiNDiPiw5mAe+Su5bGo7pjmpN70oc+h+c0P2wzK018DQ7WtRDoMNvFGmflJ9HX9eW/kZzebXg=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@simplepdf/web-embed-pdf/-/web-embed-pdf-1.8.2.tgz",
+      "integrity": "sha512-7Dje+sR9u5egC7sWMuDsvWFzRfvwHEUO/2R/vxm2tRkTLrFU4aFHT3sy3Bis99xMzSxujYF8t0pzKVvXmVzBcQ=="
     },
     "prettier": {
       "version": "3.3.3",

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -12,7 +12,7 @@
     "package": "npm ci --production && zip -r release.zip . -x .prettierignore .prettierrc package-lock.json"
   },
   "dependencies": {
-    "@simplepdf/web-embed-pdf": "^1.8.1"
+    "@simplepdf/web-embed-pdf": "^1.8.2"
   },
   "devDependencies": {
     "prettier": "^3.3.3"


### PR DESCRIPTION
## Background

Update the @simplepdf/web-embed-pdf dependency that fixes the issue where the document name was incorrectly inferred from the URL.

This resulted in very long download name.

## Changes

- Update the dependency
- Update the Chrome extension manifest version