### PR TITLE
feat: documents link support

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@simplepdf/web-embed-pdf",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@simplepdf/web-embed-pdf",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simplepdf/web-embed-pdf",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "SimplePDF straight into your website",
   "repository": {
     "type": "git",

--- a/web/src/__tests__/shared.test.ts
+++ b/web/src/__tests__/shared.test.ts
@@ -12,22 +12,31 @@ describe('getSimplePDFElements', () => {
         <a href="https://pdfobject.com/pdf/sample-3pp.pdf">PDF link</a>
         <a href="https://example.com/some-pdf-without-extension" class="simplepdf">Regular link with class</a>
         <button class="simplepdf">Button with class</button>
-        <a href="https://yourcompany.simplepdf.com/form/d8d57ec7-f3e9-4fc9-8cc5-4a92c02d30d0" class="simplepdf">SimplePDF form link</a>
+        <a href="https://yourcompany.simplepdf.com/form/d8d57ec7-f3e9-4fc9-8cc5-4a92c02d30d0">SimplePDF form link</a>
+        <a href="https://yourcompany.simplepdf.com/documents/d8d57ec7-f3e9-4fc9-8cc5-4a92c02d30d0">SimplePDF document link</a>
         <!--Should NOT detect below-->
         <a href="https://pdfobject.com/pdf/sample-3pp.pdf" class="exclude-simplepdf">PDF link with class exclusion</a>
         <a href="https://yourcompany.simplepdf.com/form/d8d57ec7-f3e9-4fc9-8cc5-4a92c02d30d0" class="exclude-simplepdf">SimplePDF form link with exclusion</a>
         <a href="https://www.pdfsomething.com/anything">Regular link containing .pdf</a>
         <a href="https://www.website.com/some-pdf">Should not be opened with SimplePDF</a>
         <a href="https://www.website.com/some-other.pdf.png">Should not be opened with SimplePDF</a>
+        <a href="https://www.simplepdf.app/s/article/How-to-Manage-PDF-Settings">Should not be opened with SimplePDF</a>
+        <a href="https://www.app.pdf/some-url">Should not be opened with SimplePDF</a>
       </body>
       </html>
     `,
       { url: 'http://localhost' },
     );
     const detectedElements = getSimplePDFElements(dom.window.document);
-    expect(detectedElements).toHaveLength(4);
+    expect(detectedElements).toHaveLength(5);
     expect(detectedElements.map(({ innerHTML }) => innerHTML)).toStrictEqual(
-      expect.arrayContaining(['Button with class', 'PDF link', 'Regular link with class', 'SimplePDF form link']),
+      expect.arrayContaining([
+        'Button with class',
+        'PDF link',
+        'Regular link with class',
+        'SimplePDF form link',
+        'SimplePDF document link',
+      ]),
     );
   });
 });

--- a/web/src/shared.ts
+++ b/web/src/shared.ts
@@ -32,8 +32,8 @@ const editorContext: EditorContext = {
   },
 };
 
-const isFormLink = (url: string) => {
-  const regex = /^https:\/\/[^.]+\.simplepdf\.com\/[^\/]+\/form\/.+/;
+const isSimplePDFLink = (url: string) => {
+  const regex = /^https:\/\/[^.]+\.simplepdf\.com(\/[^\/]+)?\/(form|documents)\/.+/;
   return regex.test(url);
 };
 
@@ -122,7 +122,7 @@ export const getSimplePDFElements = (document: Document): Element[] => {
         return false;
       }
 
-      return isPDFLink(anchor.href) || anchor.classList.contains('simplepdf') || isFormLink(anchor.href);
+      return isPDFLink(anchor.href) || anchor.classList.contains('simplepdf') || isSimplePDFLink(anchor.href);
     });
 
     return anchorsWithPDF;


### PR DESCRIPTION
## Background

Add support for the `/documents/ID` format returned by the [SimplePDF API](https://simplepdf.com/api/)

## Changes

- [x] Update regex
- [x] Update tests
- [x] Publish web-embed-pdf