### PR TITLE
fix(ci): green the changeset Version PR (format generated files, skip its changeset check)

### DIFF
--- a/.github/workflows/changeset-check.yaml
+++ b/.github/workflows/changeset-check.yaml
@@ -12,6 +12,9 @@ jobs:
   check:
     name: Require Changeset
     runs-on: ubuntu-latest
+    # The auto-generated Version PR (changeset-release/main) consumes the changesets to
+    # produce the version bump, so it legitimately has none — don't require one of it.
+    if: github.head_ref != 'changeset-release/main'
 
     steps:
       - name: Checkout code

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "changeset version && npm run --prefix react format",
     "publish": "changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
## Background

The auto-generated **"Version Packages"** PR (`changeset-release/main` — the one whose merge publishes the npm packages) fails two checks, both quirks of the Version PR rather than code problems:

- **React "Formatting"**: `changeset version` writes `package.json` + `CHANGELOG.md` in changesets' formatting, which `prettier --check` rejects.
- **"Require Changeset"**: the Version PR *consumes* the changesets to produce the bump, so it legitimately has none — but `changeset-check` demands one on every react/web PR.

Both recur on every release. Surfaced while shipping P074 (the embed/react consolidation), whose Version PR is currently red.

## Changes

- The root `version` script runs `prettier --write` on `react` after `changeset version`, so the generated `package.json` + `CHANGELOG.md` come out prettier-clean.
- `changeset-check.yaml` skips the auto-generated `changeset-release/main` branch (it carries no changeset by design).

## Notes

After this merges, `release.yaml` re-runs and regenerates the Version PR green; merging that publishes `@simplepdf/embed@0.5.0` + `@simplepdf/react-embed-pdf@1.11.0`.
