### PR TITLE
fix(ci): build workspaces before publish so react finds embed's types

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Build in dependency order (workspaces: embed → react → web) so each package's
+      # types exist before the next builds. Without this, changeset publish's
+      # prepublishOnly hooks race: react's rollup type-checks against @simplepdf/embed's
+      # .d.ts, which isn't generated yet → TS7016 → the publish aborts before anything ships.
+      - name: Build packages
+        run: npm run build --workspaces --if-present
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1


### PR DESCRIPTION
## Background

Merging the Version PR (#28) triggered the publish, but it **failed before shipping anything** (npm still at `@simplepdf/embed@0.4.0` / `@simplepdf/react-embed-pdf@1.10.0`).

`release.yaml` has no build step — it relies on `changeset publish`'s `prepublishOnly` hooks. But those don't build in dependency order: `react`'s `prepublishOnly` (`rollup -c`) runs before `@simplepdf/embed`'s type declarations exist, so `rpt2` can't resolve `@simplepdf/embed` / `/tools` / `/ai-sdk` (TS7016) and the whole publish aborts. `dist` is gitignored, so CI must build it — and the ordering can't be left to the publish hooks.

## Changes

- `release.yaml` builds all workspaces in dependency order (`embed → react → web`) before the publish step, so each package's types exist before the next builds.

## Notes

Verified locally from a clean `dist`: `npm run build --workspaces --if-present` builds embed (8 `.d.ts`) then react with no TS7016, exit 0. Merging this re-runs `release.yaml` on `main` (the changesets are already consumed, so it takes the publish path) → builds → publishes `0.5.0` / `1.11.0`.
