### PR TITLE
chore(deps): bump @simplepdf/react-embed-pdf to 1.11.0 across examples + copilot

### DIFF
--- a/copilot/package-lock.json
+++ b/copilot/package-lock.json
@@ -14,7 +14,8 @@
         "@ai-sdk/openai": "^3.0.53",
         "@ai-sdk/react": "^3.0.170",
         "@aws-sdk/client-s3": "^3.1034.0",
-        "@simplepdf/embed": "^0.4.0",
+        "@simplepdf/embed": "0.5.0",
+        "@simplepdf/react-embed-pdf": "1.11.0",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-devtools": "latest",
         "@tanstack/react-router": "latest",
@@ -2926,10 +2927,30 @@
       ]
     },
     "node_modules/@simplepdf/embed": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@simplepdf/embed/-/embed-0.4.0.tgz",
-      "integrity": "sha512-pcgzfTbMwv3U6L2FuRZAV97/dnaRqSwmlKwfqHyDWXImDGNdnV/gVcK4mid6bIQPgUBGuNmbQbU61GA+UjBKyA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@simplepdf/embed/-/embed-0.5.0.tgz",
+      "integrity": "sha512-FQZpPQdqCGeCy5rOMTQNMI0v5mXR46a1wuD1z3eSPARv+BrC1s0dLYmLqZ6j3xKQWIDjcCk/arHThsLC1Glygw==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@simplepdf/react-embed-pdf": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@simplepdf/react-embed-pdf/-/react-embed-pdf-1.11.0.tgz",
+      "integrity": "sha512-txYnZXBGFVXiiI4zpDBp6N4dE9PJZzRWnIRFM4ijFKz8v4Os+oNcg1znoAxAdFS/nPCsyrBlEq/hW//Kv+XrZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simplepdf/embed": "^0.5.0"
+      },
       "engines": {
         "node": ">=18"
       },
@@ -2939,12 +2960,6 @@
         "zod": "^4.0.0"
       },
       "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
         "zod": {
           "optional": true
         }

--- a/examples/with-custom-sidebar/package-lock.json
+++ b/examples/with-custom-sidebar/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@radix-ui/react-slot": "1.1.1",
         "@radix-ui/react-switch": "1.1.2",
-        "@simplepdf/react-embed-pdf": "latest",
+        "@simplepdf/react-embed-pdf": "^1.11.0",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -42,6 +42,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
     "node_modules/@img/sharp-darwin-x64": {
       "version": "0.33.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
@@ -63,6 +95,22 @@
         "@img/sharp-libvips-darwin-x64": "1.0.4"
       }
     },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/@img/sharp-libvips-darwin-x64": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
@@ -74,6 +122,327 @@
       "os": [
         "darwin"
       ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -467,13 +836,43 @@
         }
       }
     },
+    "node_modules/@simplepdf/embed": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@simplepdf/embed/-/embed-0.5.0.tgz",
+      "integrity": "sha512-FQZpPQdqCGeCy5rOMTQNMI0v5mXR46a1wuD1z3eSPARv+BrC1s0dLYmLqZ6j3xKQWIDjcCk/arHThsLC1Glygw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@simplepdf/react-embed-pdf": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@simplepdf/react-embed-pdf/-/react-embed-pdf-1.9.0.tgz",
-      "integrity": "sha512-qp0K5Fh8E+Zk7m3vyHtvksNlozOUyYRG2wR/TiEjhNh12kj+ar4N+1rEJA7BOsf/M2HnSplwjNOPuci2CKkKGg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@simplepdf/react-embed-pdf/-/react-embed-pdf-1.11.0.tgz",
+      "integrity": "sha512-txYnZXBGFVXiiI4zpDBp6N4dE9PJZzRWnIRFM4ijFKz8v4Os+oNcg1znoAxAdFS/nPCsyrBlEq/hW//Kv+XrZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simplepdf/embed": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
       "peerDependencies": {
         "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0"
+        "react-dom": "^18.2.0 || ^19.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@swc/counter": {
@@ -947,6 +1346,20 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {

--- a/examples/with-custom-sidebar/package.json
+++ b/examples/with-custom-sidebar/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "1.1.1",
     "@radix-ui/react-switch": "1.1.2",
-    "@simplepdf/react-embed-pdf": "latest",
+    "@simplepdf/react-embed-pdf": "^1.11.0",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/examples/with-next-js/package-lock.json
+++ b/examples/with-next-js/package-lock.json
@@ -8,7 +8,7 @@
       "name": "with-next-js",
       "version": "0.1.0",
       "dependencies": {
-        "@simplepdf/react-embed-pdf": "^1.8.4",
+        "@simplepdf/react-embed-pdf": "^1.11.0",
         "next": "^15.1.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -759,13 +759,43 @@
       "integrity": "sha512-kkKUDVlII2DQiKy7UstOR1ErJP8kUKAQ4oa+SQtM0K+lPdmmjj0YnnxBgtTVYH7mUKtbsxeFC9y0AmK7Yb78/A==",
       "dev": true
     },
+    "node_modules/@simplepdf/embed": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@simplepdf/embed/-/embed-0.5.0.tgz",
+      "integrity": "sha512-FQZpPQdqCGeCy5rOMTQNMI0v5mXR46a1wuD1z3eSPARv+BrC1s0dLYmLqZ6j3xKQWIDjcCk/arHThsLC1Glygw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@simplepdf/react-embed-pdf": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@simplepdf/react-embed-pdf/-/react-embed-pdf-1.8.4.tgz",
-      "integrity": "sha512-diworj2xPN279EXEKr8Ifv1oZSFILiGFjwMuNe9IM5P2Jkuofi+bk1hg69t4unkocH74OWdwSn6AnTkVNGvcNg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@simplepdf/react-embed-pdf/-/react-embed-pdf-1.11.0.tgz",
+      "integrity": "sha512-txYnZXBGFVXiiI4zpDBp6N4dE9PJZzRWnIRFM4ijFKz8v4Os+oNcg1znoAxAdFS/nPCsyrBlEq/hW//Kv+XrZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simplepdf/embed": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
       "peerDependencies": {
         "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0"
+        "react-dom": "^18.2.0 || ^19.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@swc/counter": {

--- a/examples/with-next-js/package.json
+++ b/examples/with-next-js/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@simplepdf/react-embed-pdf": "^1.8.4",
+    "@simplepdf/react-embed-pdf": "^1.11.0",
     "next": "^15.1.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/with-remix/package-lock.json
+++ b/examples/with-remix/package-lock.json
@@ -9,7 +9,7 @@
         "@remix-run/node": "^2.8.1",
         "@remix-run/react": "^2.8.1",
         "@remix-run/serve": "^2.8.1",
-        "@simplepdf/react-embed-pdf": "^1.8.4",
+        "@simplepdf/react-embed-pdf": "^1.11.0",
         "isbot": "^4.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -1983,13 +1983,43 @@
         "win32"
       ]
     },
+    "node_modules/@simplepdf/embed": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@simplepdf/embed/-/embed-0.5.0.tgz",
+      "integrity": "sha512-FQZpPQdqCGeCy5rOMTQNMI0v5mXR46a1wuD1z3eSPARv+BrC1s0dLYmLqZ6j3xKQWIDjcCk/arHThsLC1Glygw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@simplepdf/react-embed-pdf": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/@simplepdf/react-embed-pdf/-/react-embed-pdf-1.8.4.tgz",
-      "integrity": "sha512-diworj2xPN279EXEKr8Ifv1oZSFILiGFjwMuNe9IM5P2Jkuofi+bk1hg69t4unkocH74OWdwSn6AnTkVNGvcNg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@simplepdf/react-embed-pdf/-/react-embed-pdf-1.11.0.tgz",
+      "integrity": "sha512-txYnZXBGFVXiiI4zpDBp6N4dE9PJZzRWnIRFM4ijFKz8v4Os+oNcg1znoAxAdFS/nPCsyrBlEq/hW//Kv+XrZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simplepdf/embed": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
       "peerDependencies": {
         "react": "^18.2.0 || ^19.0.0",
-        "react-dom": "^18.2.0 || ^19.0.0"
+        "react-dom": "^18.2.0 || ^19.0.0",
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/acorn": {

--- a/examples/with-remix/package.json
+++ b/examples/with-remix/package.json
@@ -14,7 +14,7 @@
     "@remix-run/node": "^2.8.1",
     "@remix-run/react": "^2.8.1",
     "@remix-run/serve": "^2.8.1",
-    "@simplepdf/react-embed-pdf": "^1.8.4",
+    "@simplepdf/react-embed-pdf": "^1.11.0",
     "isbot": "^4.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## Background

`@simplepdf/embed@0.5.0` + `@simplepdf/react-embed-pdf@1.11.0` are now published. The repo's own consumers of `@simplepdf/react-embed-pdf` were pinned to older versions, so their lockfiles resolved stale and wouldn't pick up the consolidation (camelCase actions, the `/ai-sdk` tools, the `@simplepdf/embed` core):

- `examples/with-remix`, `examples/with-next-js`: `^1.8.4`
- `examples/with-custom-sidebar`: `"latest"`, but its lock was stuck at `1.9.0`
- `copilot`: pinned `1.11.0` but its lockfile was missing the dependency entirely (`npm ci` would have failed)

## Changes

- `examples/with-remix`, `examples/with-next-js`: `^1.8.4` → `^1.11.0`.
- `examples/with-custom-sidebar`: `"latest"` → `^1.11.0` — an explicit, reproducible pin consistent with the other examples (the floating `"latest"` left the lock stranded at `1.9.0`).
- Regenerated all consumer lockfiles (the three examples + `copilot`) so each resolves `@simplepdf/react-embed-pdf@1.11.0` and its transitive `@simplepdf/embed@0.5.0`.

## Notes

`@simplepdf/embed` references were already at `0.5.0` everywhere (`copilot`, `react`), so no embed bumps were needed. If you'd rather keep `examples/with-custom-sidebar` floating on `"latest"`, say so and I'll revert just that line (the lock stays at `1.11.0` either way).
