### PR TITLE
chore: pin react's @simplepdf/embed to an exact version (controlled rollout)

### DIFF
--- a/.changeset/pin-embed-exact.md
+++ b/.changeset/pin-embed-exact.md
@@ -1,0 +1,5 @@
+---
+"@simplepdf/react-embed-pdf": patch
+---
+
+Pin `@simplepdf/embed` to an exact version (`0.6.0`) instead of the `^0.6.0` caret. A published `@simplepdf/react-embed-pdf` now always installs the exact embed build it was tested against, giving us full control over the embed rollout: react ships a known embed version, and moving it is a deliberate release step rather than a caret range resolved at the consumer's install time.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ https://github.com/SimplePDF/simplepdf-embed/assets/10613140/8924f018-6076-4e44-
 - ⚛️ [React component](./react/README.md) - `@simplepdf/react-embed-pdf`
 - 🧩 [Iframe bridge](./embed/README.md) - `@simplepdf/embed` (framework-free client to embed + programmatically drive the editor, with an AI SDK adapter)
 - 🚀 [Script tag](./web/README.md) - `@simplepdf/web-embed-pdf`
-- 🤖 [SimplePDF Copilot](./copilot/README.md) - AI form-filling reference implementation
+- 🤖 [SimplePDF Copilot](./copilot/README.md) - ready-to-fork demo of the editor's agentic capabilities
 
 # Features
 
@@ -51,7 +51,7 @@ https://github.com/SimplePDF/simplepdf-embed/assets/10613140/8924f018-6076-4e44-
 - Page manipulation: add, remove, rotate, re-arrange
 - White-label and headless mode (Pro plan+)
 - Webhooks, API, bring-your-own-storage: S3, Azure Blob Storage, SharePoint
-- AI [Copilot](./copilot/README.md) that fills forms step-by-step (opt-in)
+- Agentic control: drive the editor from an LLM with client-side tool calling (Vercel AI SDK + TanStack AI)
 - Tiny footprint (~5KB gzipped) - the editor lazy-loads on user interaction
 
 # Built for healthcare and privacy-sensitive products
@@ -62,7 +62,7 @@ PHI never leaves the browser unless you explicitly enable submissions. BAA avail
 
 # AI Copilot
 
-AI that helps users fill PDF forms step by step, inside the SimplePDF editor.
+A ready-to-fork demo that demonstrates the editor's agentic capabilities: an LLM drives the SimplePDF editor through client-side tool calling.
 
 Copilot is a turn-key, MIT-licensed reference implementation. Users answer in plain language; Copilot maps answers to the right fields, asks for what's missing, and the user reviews and signs. Fork it, wire up your AI provider, and ship it inside your product without writing the iframe bridge, tool plumbing, or streaming chat from scratch.
 

--- a/embed/README.md
+++ b/embed/README.md
@@ -4,6 +4,16 @@ Embed and programmatically drive the [SimplePDF](https://simplepdf.com) editor o
 
 > Using React? Use [`@simplepdf/react-embed-pdf`](../react): `<EmbedPDF>` + `useEmbed` (+ the agentic `tools`), built on this core.
 
+## Install
+
+```bash
+npm install @simplepdf/embed
+```
+
+Zero runtime dependencies at the root. `zod` is an optional peer, needed by the `/schemas`, `/tools`, `/ai-sdk`, and `/tanstack-ai` subpaths. `/ai-sdk` produces values for the Vercel AI SDK without importing `ai` (bring your own); `/tanstack-ai` uses `@tanstack/ai`'s `toolDefinition` (also an optional peer, pulled only by that subpath).
+
+See [Subpaths](#subpaths) for more details.
+
 ## Quick start
 
 `createEmbed` builds the editor iframe and appends it to a container you provide:
@@ -61,14 +71,6 @@ import { clientTools } from '@tanstack/ai-react'
 import { createSimplePDFTools } from '@simplepdf/embed/tanstack-ai'
 useChat({ connection, tools: clientTools(...createSimplePDFTools({ embed })) })
 ```
-
-## Install
-
-```bash
-npm install @simplepdf/embed
-```
-
-Zero runtime dependencies at the root. `zod` is an optional peer, needed by the `/schemas`, `/tools`, `/ai-sdk`, and `/tanstack-ai` subpaths. `/ai-sdk` produces values for the Vercel AI SDK without importing `ai` (bring your own); `/tanstack-ai` uses `@tanstack/ai`'s `toolDefinition` (also an optional peer, pulled only by that subpath).
 
 ## Subpaths
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "embed": {
       "name": "@simplepdf/embed",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@tanstack/ai": "^0.38.0",
@@ -5698,10 +5698,10 @@
     },
     "react": {
       "name": "@simplepdf/react-embed-pdf",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "MIT",
       "dependencies": {
-        "@simplepdf/embed": "^0.5.0"
+        "@simplepdf/embed": "0.6.0"
       },
       "devDependencies": {
         "@rollup/plugin-terser": "^0.4.4",

--- a/react/package.json
+++ b/react/package.json
@@ -49,7 +49,7 @@
     "check:api": "node ../scripts/check-api.mjs ."
   },
   "dependencies": {
-    "@simplepdf/embed": "^0.6.0"
+    "@simplepdf/embed": "0.6.0"
   },
   "peerDependencies": {
     "@tanstack/ai": "^0.38.0",


### PR DESCRIPTION
## Background

`@simplepdf/react-embed-pdf` depended on `@simplepdf/embed` via a caret range (`^0.6.0`), so a consumer installing react resolves embed to whatever `0.6.x` npm offers at install time, not necessarily the build react was tested against.

## Changes

- Pin react's `@simplepdf/embed` dependency to the exact `0.6.0` (was `^0.6.0`), so a published `@simplepdf/react-embed-pdf` always installs the exact embed build it ships with.
- Sync the lockfile.
- Add a `@simplepdf/react-embed-pdf` `patch` changeset.

## Notes

- **Full rollout control:** moving react's embed version becomes a deliberate release step (changesets updates the exact pin and bumps react together), not a caret resolved at the consumer's install time.
- This pin depends on `@simplepdf/embed@0.6.0` actually being published (the `#44` version bump). npm currently still shows `0.5.0`, so confirm the `0.6.0` publish has landed before/with this release.
